### PR TITLE
Remove em dashes and rewrite copy in a natural voice

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gourab Roy — Machine Learning Engineer & Researcher</title>
+    <title>Gourab Roy | Machine Learning Engineer & Researcher</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ const projects = [
   },
   {
     name: "Vision-Language Model (Frozen Encoder Alignment)",
-    description: "LLaVA-style Stage-1 feature alignment bridging a frozen CLIP ViT-B/32 encoder and a frozen Qwen2.5-0.5B LLM with a lightweight trainable MLP connector — training only ~1.49M of ~582M params on the full LLaVA-ReCap corpus (~558K samples).",
+    description: "LLaVA-style Stage-1 feature alignment that bridges a frozen CLIP ViT-B/32 encoder and a frozen Qwen2.5-0.5B LLM with a lightweight trainable MLP connector. Only ~1.49M of ~582M params are trained, on the full LLaVA-ReCap corpus (~558K samples).",
     tags: ["VLM", "CLIP", "Qwen2.5", "PyTorch"],
     repo: "crimsonKn1ght/vlm-model",
     extraLinks: [{ label: "Weights (HF)", url: "https://huggingface.co/grKnight/vlm-basic-connector-full/tree/main" }],
@@ -160,7 +160,7 @@ const projects = [
   },
   {
     name: "Scalable RAG System",
-    description: "Hybrid retrieval pipeline with semantic reranking, vector deduplication, and semantic routing across multi-index stores (OpenAI or local SBERT embeddings), plus advanced query formulation — Multi-query, RAG-Fusion, HyDE, CRAG, and Self-RAG.",
+    description: "Hybrid retrieval pipeline with semantic reranking, vector deduplication, and semantic routing across multi-index stores (OpenAI or local SBERT embeddings). It also supports advanced query-formulation methods like Multi-query, RAG-Fusion, HyDE, CRAG, and Self-RAG.",
     tags: ["RAG", "SBERT", "Hybrid Search", "Reranking"],
     repo: "crimsonKn1ght/rag-llm",
     icon: <ChartBar className="w-5 h-5 text-white" />
@@ -388,8 +388,8 @@ function App() {
     }, []);
 
     const publications = [
-        { id: 'osteoarthritis', image: publicationImage1, status: 'Published • Best Paper', statusColor: 'bg-green-500/20 text-green-300', meta: 'ISAI 2025 • Springer LNNS', title: 'Knee Osteoarthritis Detection and Categorization using Deep Learning Models', description: 'Achieved 80.46% accuracy in classifying knee X-ray images using the Kellgren-Lawrence grading scale.', tags: ['Deep Learning', 'Medical Imaging', 'Classification'], paperLink: { url: 'https://link.springer.com/chapter/10.1007/978-981-96-9239-2_9', label: 'Springer' }, details: { title: "Knee Osteoarthritis Detection and Categorization using Deep Learning Models", content: (<><p className="mb-4">Published in the Proceedings of ISAI 2025, Lecture Notes in Networks and Systems (Springer), and awarded one of three Best Paper Awards out of 78 accepted submissions.</p><p className="mb-4">This research achieved 80.46% accuracy in classifying knee X-ray images based on osteoarthritis severity using a deep learning model trained on the Kellgren-Lawrence (KL) grading scale.</p><a href="https://link.springer.com/chapter/10.1007/978-981-96-9239-2_9" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline underline-offset-2">Read on Springer →</a></>) }, codeLink: 'https://github.com/crimsonkn1ght/Code-OA-detection-model' },
-        { id: 'osteoporosis', image: publicationImage2, status: 'Accepted', statusColor: 'bg-green-500/20 text-green-300', meta: 'ICADCML 2026', title: 'Texture-based Feature Extraction and CBAM-Enhanced U-Net for Automated Knee Osteoporosis Detection', description: 'Novel framework achieving 88% binary and 84% multi-class classification accuracy for osteoporosis detection.', tags: ['U-Net', 'Attention Mechanism', 'Feature Extraction'], details: { title: "Texture-based Feature Extraction and CBAM-Enhanced U-Net for Automated Knee Osteoporosis Detection", content: (<><p className="mb-4">Accepted at the International Conference on Advances in Distributed Computing and Machine Learning (ICADCML 2026).</p><p>A deep learning-based binary classification model was developed for detecting knee osteoporosis from X-ray images, achieving 88% and 84% accuracy in binary and multi-class osteoporosis classification, respectively.</p></>) }, codeLink: 'https://github.com/crimsonkn1ght/Code-OP-detection-model' },
+        { id: 'osteoarthritis', image: publicationImage1, status: 'Published • Best Paper', statusColor: 'bg-green-500/20 text-green-300', meta: 'ISAI 2025 • Springer LNNS', title: 'Knee Osteoarthritis Detection and Categorization using Deep Learning Models', description: 'Achieved 80.46% accuracy in classifying knee X-ray images using the Kellgren-Lawrence grading scale.', tags: ['Deep Learning', 'Medical Imaging', 'Classification'], paperLink: { url: 'https://link.springer.com/chapter/10.1007/978-981-96-9239-2_9', label: 'Springer' }, details: { title: "Knee Osteoarthritis Detection and Categorization using Deep Learning Models", content: (<><p className="mb-4">Published in the Proceedings of ISAI 2025, Lecture Notes in Networks and Systems (Springer), and awarded one of three Best Paper Awards out of 78 accepted submissions.</p><p className="mb-4">The model reached 80.46% accuracy classifying knee X-ray images by osteoarthritis severity, trained on the Kellgren-Lawrence (KL) grading scale.</p><a href="https://link.springer.com/chapter/10.1007/978-981-96-9239-2_9" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline underline-offset-2">Read on Springer →</a></>) }, codeLink: 'https://github.com/crimsonkn1ght/Code-OA-detection-model' },
+        { id: 'osteoporosis', image: publicationImage2, status: 'Accepted', statusColor: 'bg-green-500/20 text-green-300', meta: 'ICADCML 2026', title: 'Texture-based Feature Extraction and CBAM-Enhanced U-Net for Automated Knee Osteoporosis Detection', description: 'A CBAM-enhanced U-Net that reaches 88% accuracy on binary and 84% on multi-class osteoporosis detection.', tags: ['U-Net', 'Attention Mechanism', 'Feature Extraction'], details: { title: "Texture-based Feature Extraction and CBAM-Enhanced U-Net for Automated Knee Osteoporosis Detection", content: (<><p className="mb-4">Accepted at the International Conference on Advances in Distributed Computing and Machine Learning (ICADCML 2026).</p><p>I built a deep learning model that detects knee osteoporosis from X-ray images, reaching 88% accuracy on binary classification and 84% on the multi-class setting.</p></>) }, codeLink: 'https://github.com/crimsonkn1ght/Code-OP-detection-model' },
         { id: 'astraqVl', image: astraqVlImage, status: 'Preprint', statusColor: 'bg-blue-500/20 text-blue-300', meta: 'Independent Research • Zenodo', title: 'AstraQ-VL: Efficient Astronomy Vision-Language Model with Frozen Encoder Alignment and LoRA Instruction Tuning', description: 'LLaVA-style astronomy VLM aligning frozen CLIP ViT-L/14 features with Qwen2.5-1.5B-Instruct, extended with LoRA-based visual instruction tuning.', tags: ['Vision-Language Models', 'Multimodal Learning', 'LoRA'], paperLink: { url: 'https://zenodo.org/records/21284851', label: 'Preprint' }, details: { title: "AstraQ-VL: Efficient Astronomy Vision-Language Model", content: (<><p className="mb-4">Independent research project: a LLaVA-style astronomy VLM built by aligning frozen CLIP ViT-L/14 features with Qwen2.5-1.5B-Instruct using a 3.9M-parameter connector, then extending to Stage-2 visual instruction tuning with LoRA adapters.</p><p className="mb-4">Trained on 161,653 caption/QA records with a 591-image held-out split; released reproducible checkpoints and model cards, with a held-out validation-loss improvement from 1.60 to 1.452 in Stage 2.</p><a href="https://zenodo.org/records/21284851" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline underline-offset-2">Zenodo Preprint →</a></>) }, codeLink: 'https://github.com/crimsonKn1ght/astraq-vl' }
     ];
 
@@ -435,7 +435,7 @@ function App() {
                     </div>
                 </nav>
 
-                {/* Hero Section — compact intro band */}
+                {/* Hero Section: compact intro band */}
                 <section id="hero" className="relative z-10 px-6 pt-32 pb-14 text-center max-w-5xl mx-auto">
                     <div ref={floatingElementsRef} className="absolute inset-0 transition-transform duration-1000 ease-out pointer-events-none">
                         <motion.div className="absolute top-1/4 left-1/4 w-32 h-32 bg-blue-500/10 rounded-full filter blur-2xl" animate={{ y: [0, 20, 0], x: [0, -10, 0] }} transition={{ duration: 8, repeat: Infinity, ease: "easeInOut" }} />
@@ -449,7 +449,7 @@ function App() {
                         <div className="border border-blue-500/50 bg-blue-500/10 backdrop-blur-sm rounded-full px-3 py-1"><span className="text-xs sm:text-sm text-blue-400 font-semibold">Machine Learning Engineer</span></div>
                         <div className="border border-blue-500/50 bg-blue-500/10 backdrop-blur-sm rounded-full px-3 py-1"><span className="text-xs sm:text-sm text-blue-400 font-semibold">Computer Vision Researcher</span></div>
                     </motion.div>
-                    <motion.p className="text-slate-400 text-sm md:text-base mb-7 max-w-2xl mx-auto" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.7, delay: 0.5 }}>Building multi-agent LLM systems, RAG pipelines, and deep learning models for medical imaging — published researcher with production exposure across LLM orchestration and real-time streaming workflows</motion.p>
+                    <motion.p className="text-slate-400 text-sm md:text-base mb-7 max-w-2xl mx-auto" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.7, delay: 0.5 }}>I build multi-agent LLM systems and RAG pipelines, and I train deep learning models for medical imaging. My research is published, and I've taken LLM and real-time streaming work into production.</motion.p>
                     <motion.div className="flex flex-wrap justify-center gap-2 sm:gap-3" variants={listContainerVariants} initial="hidden" animate="visible" transition={{ delay: 0.6 }}>
                         <motion.a variants={listItemVariants} href="mailto:gourab.roy.aiml@gmail.com" target="_blank" rel="noopener noreferrer" className="group flex items-center space-x-2 bg-white/5 hover:bg-blue-500/20 backdrop-blur-sm border border-white/10 hover:border-blue-500/50 rounded-full px-4 py-2 transition-all duration-300">
                             <MailsIcon size={16} className="text-slate-400 group-hover:text-blue-400 transition-colors" />
@@ -480,7 +480,7 @@ function App() {
                                     <BookmarkIcon size={28} className="mr-3 text-purple-400" />
                                     Research Publications
                                 </h2>
-                                <p className="text-sm text-slate-400 max-w-3xl">Peer-reviewed research and preprints in AI and computer vision</p>
+                                <p className="text-sm text-slate-400 max-w-3xl">My peer-reviewed papers and preprints in AI and computer vision</p>
                             </div>
                             <motion.div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5" variants={listContainerVariants} initial="hidden" whileInView="visible" viewport={{ once: true }}>
                                 {publications.map((pub) => (
@@ -499,7 +499,7 @@ function App() {
                                     <BlocksIcon size={28} className="mr-3 text-blue-400" />
                                     Featured Projects
                                 </h2>
-                                <p className="text-sm text-slate-400 max-w-3xl">Open-source implementations and practical applications of AI/ML concepts</p>
+                                <p className="text-sm text-slate-400 max-w-3xl">Open-source things I've built, from ML research to full-stack apps</p>
                             </div>
                             <motion.div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5" variants={listContainerVariants} initial="hidden" whileInView="visible" viewport={{ once: true }}>
                                 {projects.map((project) => (
@@ -518,7 +518,7 @@ function App() {
                                     <StarIcon size={28} className="mr-3 text-yellow-400" />
                                     Awards & Test Scores
                                 </h2>
-                                <p className="text-sm text-slate-400 max-w-3xl">Recognition, standardized test performance, and professional credentials</p>
+                                <p className="text-sm text-slate-400 max-w-3xl">Recognition, test scores, and a few professional credentials</p>
                             </div>
 
                             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
@@ -526,21 +526,21 @@ function App() {
                                     chip="ISAI 2025" chipColor="bg-yellow-500/20 text-yellow-300" emoji="🏆"
                                     title="Best Paper Award"
                                     org="International Symposium on Artificial Intelligence, NIT Sikkim"
-                                    description="One of three Best Paper Awards out of 78 accepted submissions, for outstanding research contribution in AI/ML"
+                                    description="One of three Best Paper Awards given out of 78 accepted submissions"
                                     image={awardImage}
                                 />
                                 <AwardCard
                                     chip="Kaggle" chipColor="bg-orange-500/20 text-orange-300" emoji="🥉"
                                     title="Bronze Medal"
                                     org="CSIRO Biomass Computer Vision Competition"
-                                    description="Finished in the top tier among global participants in the CSIRO Biomass computer vision competition on Kaggle"
+                                    description="A top-tier finish in the CSIRO Biomass computer vision competition on Kaggle"
                                     image={kaggleMedalImage}
                                 />
                                 <AwardCard
                                     chip="Invited Talk" chipColor="bg-purple-500/20 text-purple-300" emoji="🎤"
                                     title="Distinguished Speaker"
                                     org="6th International Conference on Future of Preventive Medicine and Public Health"
-                                    description="Invited as a Distinguished Speaker to present research at the international conference"
+                                    description="Invited to present my research as a distinguished speaker at the conference"
                                     image={speakerCertImage}
                                 />
                             </div>
@@ -598,7 +598,7 @@ function App() {
                                     <BoltIcon size={28} className="mr-3 text-yellow-400" />
                                     Technical Expertise
                                 </h2>
-                                <p className="text-sm text-slate-400 max-w-3xl">Skill set spanning AI/ML, computer vision, and data science</p>
+                                <p className="text-sm text-slate-400 max-w-3xl">The tools and areas I work with across AI/ML, computer vision, and data science</p>
                             </div>
                             <div className="grid md:grid-cols-2 gap-5 items-start">
                                 {Object.entries(skills).map(([category, skillList]) => (
@@ -642,7 +642,7 @@ function App() {
                                     </div>
                                     <span className="text-base font-bold text-white">Gourab Roy</span>
                                 </div>
-                                <p className="text-slate-400 text-sm mb-4">Machine learning engineer and researcher advancing computer vision and medical imaging through deep learning.</p>
+                                <p className="text-slate-400 text-sm mb-4">Machine learning engineer and researcher working on computer vision and medical imaging.</p>
                                 <div className="flex space-x-4">
                                     <a href="mailto:gourab.roy.aiml@gmail.com" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-blue-400 transition-colors"><MailsIcon className="w-4 h-4" /></a>
                                     <a href="https://www.linkedin.com/in/gourab-roy/" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-blue-400 transition-colors"><LinkedInIcon className="w-4 h-4" /></a>

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -28,12 +28,12 @@ export function TimelineDemo() {
         <div>
           <BackgroundGradient containerClassName="rounded-2xl">
             <div className="mb-5 bg-slate-800/60 border border-slate-700 rounded-2xl p-4 sm:p-5">
-              <EntryHeader role="Data Scientist" org="Axtria, Bengaluru" period="Sept 2025 – Present" logo={axtriaLogo} logoAlt="Axtria" />
+              <EntryHeader role="Data Scientist" org="Axtria, Bengaluru" period="Sept 2025 - Present" logo={axtriaLogo} logoAlt="Axtria" />
               <p className="text-xs sm:text-sm text-slate-300 italic mb-2">Multi-agent LLM platform for enterprise insights, retrieval-augmented analytics, and real-time conversational workflows.</p>
               <ul className="list-disc list-inside text-xs sm:text-sm text-white space-y-1">
                 <li>Architected a multi-agent LangGraph workflow handling query decomposition, intent classification, retrieval orchestration, analytical tool execution, and web-augmented LLM reasoning with redaction and citation formatting.</li>
                 <li>Built an asynchronous hybrid/vector retrieval pipeline on Azure AI Search with metadata-aware filtering, semantic reranking, vector deduplication, and parallel multi-index orchestration for grounded retrieval.</li>
-                <li>Re-architected agent execution with asynchronous orchestration and decoupled processing paths, cutting time-to-first-token (TTFT) from ~90s to 10–20s.</li>
+                <li>Re-architected agent execution with asynchronous orchestration and decoupled processing paths, cutting time-to-first-token (TTFT) from ~90s to 10-20s.</li>
                 <li>Optimized end-to-end pipeline latency by eliminating redundant LLM calls and parallelizing independent calls with asynchronous execution.</li>
                 <li>Implemented token-level streaming across OpenAI, Gemini, and Claude via streaming-compatible handlers and event-processing workflows for real-time, user-facing responses.</li>
                 <li>Designed a query rephrasing pipeline to refine user inputs, improving retrieval accuracy and downstream agent routing in the chatbot workflow.</li>
@@ -42,7 +42,7 @@ export function TimelineDemo() {
           </BackgroundGradient>
           <BackgroundGradient containerClassName="rounded-2xl">
             <div className="mb-5 bg-slate-800/60 border border-slate-700 rounded-2xl p-4 sm:p-5">
-              <EntryHeader role="Research Intern — Deep Learning for Medical Imaging" org="IIT Kharagpur" period="May 2025 – Sept 2025" logo={iitKharagpurLogo} logoAlt="IIT Kharagpur" />
+              <EntryHeader role="Research Intern, Deep Learning for Medical Imaging" org="IIT Kharagpur" period="May 2025 - Sept 2025" logo={iitKharagpurLogo} logoAlt="IIT Kharagpur" />
               <ul className="list-disc list-inside text-xs sm:text-sm text-white space-y-1">
                 <li>Built and trained a modified U-Net for CT image reconstruction on 20,000+ sinogram-image pairs, targeting sparse-view and low-dose acquisition scenarios relevant to real clinical workflows.</li>
                 <li>Achieved PSNR of 35 dB+ and SSIM of 0.9+, validating reconstruction quality across varying levels of projection sparsity and measurement noise.</li>
@@ -51,10 +51,10 @@ export function TimelineDemo() {
           </BackgroundGradient>
           <BackgroundGradient containerClassName="rounded-2xl">
             <div className="mb-5 bg-slate-800/60 border border-slate-700 rounded-2xl p-4 sm:p-5">
-              <EntryHeader role="M.Tech in Computer Science and Engineering" org="IIT (ISM) Dhanbad" period="2023 – 2025 · GPA: 8.57/10" logo={iitDhanbadLogo} logoAlt="IIT Dhanbad" />
+              <EntryHeader role="M.Tech in Computer Science and Engineering" org="IIT (ISM) Dhanbad" period="2023 - 2025 · GPA: 8.57/10" logo={iitDhanbadLogo} logoAlt="IIT Dhanbad" />
               <ul className="list-disc list-inside text-xs sm:text-sm text-white space-y-1">
                   <li><b>Thesis:</b> Multi-Stage Deep Learning Framework for Knee Osteoarthritis & Osteoporosis Detection. Achieved 80.46% accuracy in multiclass classification of osteoarthritis severity and 88% accuracy in binary classification of osteoporosis from knee X-ray images.</li>
-                  <li>Published 2 peer-reviewed papers from thesis work — 1 Best Paper Award at ISAI 2025 (Springer LNNS) and 1 accepted at ICADCML 2026.</li>
+                  <li>Published 2 peer-reviewed papers from the thesis: a Best Paper winner at ISAI 2025 (Springer LNNS), and one accepted at ICADCML 2026.</li>
                   <li><b>Relevant coursework:</b> Deep Learning, Computer Vision, NLP, Pattern Recognition.</li>
               </ul>
             </div>
@@ -68,9 +68,9 @@ export function TimelineDemo() {
         <div>
           <BackgroundGradient containerClassName="rounded-2xl">
             <div className="mb-5 bg-slate-800/60 border border-slate-700 rounded-2xl p-4 sm:p-5">
-              <EntryHeader role="Data Science Intern" org="Axtria, Bengaluru" period="May – July 2024" logo={axtriaLogo} logoAlt="Axtria" />
+              <EntryHeader role="Data Science Intern" org="Axtria, Bengaluru" period="May - July 2024" logo={axtriaLogo} logoAlt="Axtria" />
               <p className="text-xs sm:text-sm text-white">
-                Built and validated time-series forecasting models on internal business data, surfacing predictive insights to support data-driven decision-making and automate recurring analytics workflows.
+                Built and validated time-series forecasting models on internal business data, and automated recurring analytics that the team used for planning.
               </p>
             </div>
           </BackgroundGradient>
@@ -83,7 +83,7 @@ export function TimelineDemo() {
         <div>
           <BackgroundGradient containerClassName="rounded-2xl">
             <div className="mb-5 bg-slate-800/60 border border-slate-700 rounded-2xl p-4 sm:p-5">
-              <EntryHeader role="B.Tech in Electronics & Telecommunications Engineering" org="IIEST Shibpur" period="2019 – 2023 · GPA: 7.58/10" logo={iiestShibpurLogo} logoAlt="IIEST Shibpur" />
+              <EntryHeader role="B.Tech in Electronics & Telecommunications Engineering" org="IIEST Shibpur" period="2019 - 2023 · GPA: 7.58/10" logo={iiestShibpurLogo} logoAlt="IIEST Shibpur" />
               <ul className="list-disc list-inside text-xs sm:text-sm text-white space-y-1">
                   <li><b>Relevant coursework:</b> Signal Processing, Digital Systems, Programming, Linear Algebra.</li>
                   <li>Graduated with First Class.</li>

--- a/src/components/ui/background-gradient.tsx
+++ b/src/components/ui/background-gradient.tsx
@@ -17,7 +17,7 @@ export const BackgroundGradient = ({
 
   return (
     <div className={cn("relative group", containerClassName)}>
-      {/* Blurred glow layer — CSS animation replaces Framer Motion for compositor-thread performance */}
+      {/* Blurred glow layer: CSS animation replaces Framer Motion for compositor-thread performance */}
       <div
         className={cn(
           "absolute inset-0 rounded-3xl z-[1] opacity-60 group-hover:opacity-100 blur-xl transition-opacity duration-500",

--- a/src/components/ui/timeline.tsx
+++ b/src/components/ui/timeline.tsx
@@ -45,7 +45,7 @@ export const Timeline = ({ data }: { data: TimelineEntry[] }) => {
             Experience & Education
           </h2>
           <p className="text-neutral-400 text-sm max-w-md">
-            A timeline of my key professional and academic milestones.
+            Where I've worked and studied over the years.
           </p>
         </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,7 @@ body {
   scrollbar-color: #4a5568 #1e293b; /* thumb color track color */
 }
 
-/* CSS gradient animation — runs on the compositor thread, no JS involvement */
+/* CSS gradient animation runs on the compositor thread, no JS involvement */
 @keyframes gradient-shift {
   0%, 100% { background-position: 0% 50%; }
   50%       { background-position: 100% 50%; }


### PR DESCRIPTION
Replace em dashes in the page title, body text, and code comments with plain punctuation, restructuring sentences instead of swapping in a uniform hyphen. Convert en-dash date ranges to simple hyphens.

Rewrite the hero blurb, section subtitles, award and publication descriptions, and footer in a plainer first-person voice, dropping filler like 'spanning', 'advancing through deep learning', 'novel framework achieving', and 'surfacing predictive insights'.